### PR TITLE
Make installable with current rakudo/panda

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,6 +3,5 @@
     "version"     : "*",
     "description" : "A proof-of-concept blogging application using Perl 6's Web.pm",
     "depends"     : ["Web"],
-    "repo-type"   : "git",
-    "repo-url"    : "git://github.com/masak/yarn.git"
+    "source-url"    : "git://github.com/masak/yarn.git"
 }

--- a/lib/Yarn.pm
+++ b/lib/Yarn.pm
@@ -3,7 +3,7 @@ use v6;
 use Web::Request;
 use Web::Response;
 
-use Tags;
+use Yarn::Tags;
 
 class Yarn {
     method call($env) {

--- a/lib/Yarn/Tags.pm
+++ b/lib/Yarn/Tags.pm
@@ -1,0 +1,60 @@
+use v6;
+module Yarn::Tags;
+
+sub show(&inner) is export {
+    # I have no idea what this sub needs to do
+    inner();
+}
+
+sub enclose($tag, $body, *%attr) {
+    my $attr;
+    for %attr.kv -> $k, $v {
+        $attr ~= " $k=\"$v\"";
+    }
+    return "<{$tag}{$attr}>{$body}</$tag>";
+}
+
+sub html(&inner) is export {
+    enclose('html', inner());
+}
+
+sub head(&inner) is export {
+    enclose('head', inner());
+}
+
+sub title(&inner) is export {
+    enclose('title', inner());
+}
+
+sub body(&inner) is export {
+    enclose('body', inner());
+}
+
+sub p(&inner) is export {
+    enclose('p', inner());
+}
+
+sub a(&inner, *%attr) is export {
+    enclose('a', inner(), |%attr);
+}
+
+sub form(&inner, *%attr) is export {
+    enclose('form', inner(), |%attr);
+    
+}
+
+sub div(&inner, *%attr) is export {
+    enclose('div', inner(), |%attr);
+}
+
+sub textarea(&inner, *%attr) is export {
+    enclose('textarea', inner(), |%attr);
+}
+
+sub input(&inner, *%attr) is export {
+    enclose('input', inner(), |%attr);
+}
+
+sub h1(&inner, *%attr) is export {
+    enclose('h1', inner(), |%attr);
+}


### PR DESCRIPTION
This patch makes yarn installable with panda (much like PR #1 and #2), and also makes tests pass by providing a 5-minute version of Yarn::Tags
